### PR TITLE
fix format/2-3 to throw a domain error on invalid radix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 Change in GNU Prolog version 1.5.1
 
 * fix issue #9: format/2-3 now also accept a list of character for format
+* fix format/2-3 to throw a domain error on invalid radix
 * fix problem in arm32 mapper when passing more than 8 double to a C function
 * fix issue #7: length/2 now emits a type_error(list) only if the strict_mode flag is on
 * fix infinite loop in debugger for multifile/dynamic predicates (issue #12)

--- a/src/BipsPl/error_supp.c
+++ b/src/BipsPl/error_supp.c
@@ -181,6 +181,7 @@ Error_Supp_Initializer(void)
 				/* for g_vars */
   pl_domain_stream_seek_method = Pl_Create_Atom("stream_seek_method"); /* for seek/4 */
   pl_domain_format_control_sequence = Pl_Create_Atom("format_control_sequence");
+  pl_domain_format_radix = Pl_Create_Atom("radix");
 				/* for format/2-3 */
   pl_domain_os_path = Pl_Create_Atom("os_path");/* for absolute_file_name/2 */
   pl_domain_os_file_permission = Pl_Create_Atom("os_file_permission");

--- a/src/BipsPl/error_supp.h
+++ b/src/BipsPl/error_supp.h
@@ -94,7 +94,8 @@ int pl_domain_term_stream_or_alias;		/* for term_streams */
 int pl_domain_g_array_index;			/* for g_vars */
 int pl_domain_g_argument_selector;		/* for g_vars */
 int pl_domain_stream_seek_method;		/* for seek/4 */
-int pl_domain_format_control_sequence;		/* for format/2-3 */
+int pl_domain_format_control_sequence;	/* for format/2-3 */
+int pl_domain_format_radix;		        /* for format/2-3 */
 int pl_domain_os_path;				/* for absolute_file_name/2 */
 int pl_domain_os_file_permission;		/* for file_permission/2 */
 int pl_domain_selectable_item;			/* for select_read/3 */
@@ -198,6 +199,7 @@ extern int pl_domain_g_array_index;		/* for g_vars */
 extern int pl_domain_g_argument_selector;	/* for g_vars */
 extern int pl_domain_stream_seek_method;	/* for seek/4 */
 extern int pl_domain_format_control_sequence;	/* for format/2-3 */
+extern int pl_domain_format_radix;	/* for format/2-3 */
 extern int pl_domain_os_path;			/* for absolute_file_name/2 */
 extern int pl_domain_os_file_permission; 	/* for file_permission/2 */
 extern int pl_domain_selectable_item; 		/* for select_read/3 */

--- a/src/BipsPl/format_c.c
+++ b/src/BipsPl/format_c.c
@@ -316,8 +316,11 @@ Format(StmInf *pstm, char *format, WamWord *lst_adr)
             case 'R':
               x = Arg_Integer(&lst_adr);
 
-              if (!has_n || n < 2 || n > 36)
-                n = 8;
+              if (!has_n)
+                  n = 8;
+              else if (n < 2 || n > 36)
+                  Pl_Err_Domain(pl_domain_format_radix,
+                                Tag_INT(n));
 
               k = ((*format == 'r') ? 'a' : 'A') - 10;
 
@@ -369,7 +372,7 @@ Format(StmInf *pstm, char *format, WamWord *lst_adr)
             case 'q':
               word = Read_Arg(&lst_adr);
               Pl_Write_Term(pstm, -1, MAX_PREC, WRITE_NUMBER_VARS |
-			    WRITE_NAME_VARS | WRITE_QUOTED, NULL, word);
+                WRITE_NAME_VARS | WRITE_QUOTED, NULL, word);
               break;
 
             case 'p':           /* only work if print.pl is linked */

--- a/src/EnginePl/gprolog.h
+++ b/src/EnginePl/gprolog.h
@@ -156,6 +156,7 @@ extern int pl_domain_g_array_index;
 extern int pl_domain_g_argument_selector;
 extern int pl_domain_stream_seek_method;
 extern int pl_domain_format_control_sequence;
+extern int pl_domain_format_radix;
 extern int pl_domain_os_path;
 extern int pl_domain_os_file_permission;
 extern int pl_domain_selectable_item;
@@ -776,6 +777,7 @@ typedef PlFIOArg FIOArg;
 #define domain_g_argument_selector pl_domain_g_argument_selector
 #define domain_stream_seek_method pl_domain_stream_seek_method
 #define domain_format_control_sequence pl_domain_format_control_sequence
+#define domain_format_radix pl_domain_format_radix
 #define domain_os_path pl_domain_os_path
 #define domain_os_file_permission pl_domain_os_file_permission
 #define domain_selectable_item pl_domain_selectable_item


### PR DESCRIPTION
This pull request fixes 36 failed tests when running Logtalk's standards compliance tests for the `format/2-3` predicates.